### PR TITLE
Fix malformatted filenames for formatted images.

### DIFF
--- a/Sources/ImageCache/FileManager.swift
+++ b/Sources/ImageCache/FileManager.swift
@@ -7,13 +7,16 @@
 //
 
 import Foundation
+import Etcetera
 
 extension FileManager {
 
     func image(fromFileAt url: URL) -> Image? {
-        if let data = try? Data(contentsOf: url) {
+        do {
+            let data = try Data(contentsOf: url)
             return Image(data: data)
-        } else {
+        } catch {
+            Log.error("Error reading image at \(url) error: \(error)")
             return nil
         }
     }
@@ -29,7 +32,9 @@ extension FileManager {
                 try removeItem(at: url)
             }
             try data.write(to: url, options: .atomic)
-        } catch {}
+        } catch {
+            Log.error("Error saving image to \(url) error: \(error)")
+        }
     }
 
 }

--- a/Sources/ImageCache/ImageKey.swift
+++ b/Sources/ImageCache/ImageKey.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 /// Uniquely identifies a particular format of an image from a particular URL.
 final class ImageKey: Hashable {
@@ -34,7 +35,14 @@ final class ImageKey: Hashable {
         case let .scaled(size, mode, bleed, opaque, radius, border, contentScale):
             let base = "_scaled_\(Int(size.width))_\(Int(size.height))_\(mode)_\(Int(bleed))_\(opaque)_\(Int(radius))_\(Int(contentScale))"
             if let border = border, case .hairline(let color) = border {
-                return base + "_hairline(\(color))"
+                var r, g, b, a: CGFloat!
+                color.getRed(&r, green: &g, blue: &b, alpha: &a)
+                func describe(_ color: CGFloat?) -> String {
+                    let multiplied = (color ?? 0) * 1_000_000
+                    let rounded = Int(multiplied) / 1000
+                    return "\(rounded)"
+                }
+                return base + "_hairline(\(describe(r)),\(describe(g)),\(describe(b)),\(describe(a)))"
             } else {
                 return base + "_nil"
             }

--- a/Sources/ImageCache/ImageKey.swift
+++ b/Sources/ImageCache/ImageKey.swift
@@ -35,21 +35,14 @@ final class ImageKey: Hashable {
         case let .scaled(size, mode, bleed, opaque, radius, border, contentScale):
             let base = "_scaled_\(Int(size.width))_\(Int(size.height))_\(mode)_\(Int(bleed))_\(opaque)_\(Int(radius))_\(Int(contentScale))"
             if let border = border, case .hairline(let color) = border {
-                var r, g, b, a: CGFloat!
-                color.getRed(&r, green: &g, blue: &b, alpha: &a)
-                func describe(_ color: CGFloat?) -> String {
-                    let multiplied = (color ?? 0) * 1_000_000
-                    let rounded = Int(multiplied) / 1000
-                    return "\(rounded)"
-                }
-                return base + "_hairline(\(describe(r)),\(describe(g)),\(describe(b)),\(describe(a)))"
+                return base + "_hairline(\(color.fileNameExpression))"
             } else {
                 return base + "_nil"
             }
         case let .round(size, border, contentScale):
             let base = "_round_\(Int(size.width))_\(Int(size.height))"
             if let border = border, case .hairline(let color) = border {
-                return base + "_hairline(\(color))" + "_\(Int(contentScale))"
+                return base + "_hairline(\(color.fileNameExpression))" + "_\(Int(contentScale))"
             } else {
                 return base + "_nil"
             }
@@ -60,6 +53,24 @@ final class ImageKey: Hashable {
 
     static func == (lhs: ImageKey, rhs: ImageKey) -> Bool {
         return lhs.url == rhs.url && lhs.format == rhs.format
+    }
+
+}
+
+extension Color {
+
+    var fileNameExpression: String {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        func describe(_ color: CGFloat) -> String {
+            let multiplied = color * 1_000_000
+            let rounded = Int(multiplied) / 1000
+            return "\(rounded)"
+        }
+        return "\(describe(r))-\(describe(g))-\(describe(b))-\(describe(a))"
     }
 
 }

--- a/Sources/ImageCache/Log.swift
+++ b/Sources/ImageCache/Log.swift
@@ -1,0 +1,13 @@
+//
+//  Log.swift
+//  ImageCache
+//
+//  Created by Jared Sinclair on 1/3/20.
+//  Copyright © 2020 Nice Boy LLC. All rights reserved.
+//
+
+import Foundation
+import os.log
+import Etcetera
+
+let Log = OSLog(subsystem: "com.niceboy.ImageCache", category: "Images")


### PR DESCRIPTION
The moral of the story is don't trust `debugDescription` to save you.